### PR TITLE
Fixes unknown iface error

### DIFF
--- a/scapy_watcher.py
+++ b/scapy_watcher.py
@@ -4,6 +4,8 @@ __author__ = "Alex 'Chozabu' P-B"
 __copyright__ = "Copyright 2016, Chozabu"
 
 
+import netifaces
+
 from threading import Thread
 from scapy.all import *
 
@@ -52,7 +54,9 @@ def pkt_callback(pkt):
     calc_speeds()
 
 def run():
-    sniff(iface="wlp3s0", prn=pkt_callback, filter="tcp", store=0)
+    ifaces = [iface for iface in netifaces.interfaces()
+              if netifaces.AF_INET in netifaces.ifaddresses(iface)]
+    sniff(iface=ifaces, prn=pkt_callback, filter="tcp", store=0)
 
 
 def launch_watcher():


### PR DESCRIPTION
This resolves https://github.com/chozabu/LinNetLim/issues/1 by using the `netifaces` module to check if the `AF_INET` family is listed under the interface.  I was looking up a work around and found a mention of this on [stackoverflow](http://stackoverflow.com/a/17680779/1230086) which references the [`netifaces`](https://github.com/raphdg/netifaces) docs